### PR TITLE
bug/bank-min-max

### DIFF
--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -1,6 +1,6 @@
 #include "CoreEntryPoint.h"
 
-#define BUILD "1.9.15"
+#define BUILD "1.9.16"
 
 CoreEntryPoint entryPoint;
 

--- a/libraries/CoreSettings/CoreSettings.cpp
+++ b/libraries/CoreSettings/CoreSettings.cpp
@@ -93,7 +93,7 @@ void CoreSettings::readFromStore()
       return;
     }
 
-    liveSettings.activeBank = doc["activeBank"] | BLUE;
+    liveSettings.activeBank =  max(RED, min(doc["activeBank"] | BLUE, WHITE));
 
     for (int i = 0; i <= 7; i++)
     {
@@ -217,8 +217,8 @@ int32_t CoreSettings::getFileSize(const char* filen)
 }
 
 void CoreSettings::setActiveBank(int iBank)
-{
-  liveSettings.activeBank = iBank;
+{ 
+  liveSettings.activeBank = max(RED, min(iBank,WHITE));
   saveToStore();
 }
 


### PR DESCRIPTION
Sence check bank number from both the JSON file and from elsewhere in the software - whether the activation loop - or from serial comms to ensure it is within the range 0-RED to 7-WHITE and cannot be 8-OFF