### PR TITLE
Added checks on gyros during arming

### DIFF
--- a/libraries/CoreSensor/CoreSensor.cpp
+++ b/libraries/CoreSensor/CoreSensor.cpp
@@ -122,8 +122,13 @@ bool CoreSensor::needArm()
     if (millis() - time < TIME_FOR_CONFIRM_ARM)
     {
       valueAccel = PROTOTYPE ? device.readFloatAccelX() : device.readFloatAccelZ();
-
-      if (containArm(valueAccel))
+      valueGyroZ = abs(PROTOTYPE ? device.readFloatGyroX() : device.readFloatGyroZ());
+      valueGyroX = abs(PROTOTYPE ? device.readFloatGyroY() : device.readFloatGyroX());
+      valueGyroY = abs(PROTOTYPE ? device.readFloatGyroZ() : device.readFloatGyroY());
+      if ((containArm(valueAccel)) && 
+          (valueGyroZ < SWING_THRESHOLD) &&
+          (valueGyroX < SWING_THRESHOLD) &&
+          (valueGyroY < SWING_THRESHOLD))
       {
         CoreLogging::writeLine("CoreSensor: Request arm...");
         isVerticalPosition = false;
@@ -146,7 +151,13 @@ bool CoreSensor::needArm()
     if (millis() - time < TIME_FOR_CONFIRM_ARM)
     {
       valueAccel = PROTOTYPE ? device.readFloatAccelX() : device.readFloatAccelZ();
-      if (containArm(valueAccel))
+      valueGyroZ = abs(PROTOTYPE ? device.readFloatGyroX() : device.readFloatGyroZ());
+      valueGyroX = abs(PROTOTYPE ? device.readFloatGyroY() : device.readFloatGyroX());
+      valueGyroY = abs(PROTOTYPE ? device.readFloatGyroZ() : device.readFloatGyroY());
+      if ((containArm(valueAccel)) && 
+          (valueGyroZ < SWING_THRESHOLD) &&
+          (valueGyroX < SWING_THRESHOLD) &&
+          (valueGyroY < SWING_THRESHOLD))
       {
         CoreLogging::writeLine("CoreSensor: Request arm and change color...");
         status = Status::armingWithChangeColor;

--- a/libraries/CoreSensor/CoreSensor.h
+++ b/libraries/CoreSensor/CoreSensor.h
@@ -53,6 +53,9 @@ private:
   uint8_t dataToWrite = 0;
 
   float valueAccel = 0.0;
+  float valueGyroX = 0.0;
+  float valueGyroY = 0.0;
+  float valueGyroZ = 0.0;
   static constexpr float minValue = VERTICAL_ACC - TOLERANCE_ARM;
   static constexpr float maxValue = VERTICAL_ACC + TOLERANCE_ARM;
   static constexpr float minArmValue = VERTICAL_ARM - TOLERANCE_ARM;


### PR DESCRIPTION
This fix closes #42 
I've just added some constraints, but probably it will be cleaner to change the containArm() function. I've used the same threshold used for swing and it seems good. If needed we could add a specific constant in the header.