### PR TITLE
Added watchdog recovery action

### DIFF
--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -89,6 +89,7 @@ void CoreMotion::action( int id ) {
       return;
     case ENT_ARMED:
       push( connectors, ON_ARMED, 0, 0, 0 );
+      timer_horizontal.setFromNow(this,TIME_FOR_DISARM);
       return;
     case LP_ARMED:
       if ((AccelZ < (HORIZONTAL_POSITION - TOLERANCE_POSITION)) || 

--- a/libraries/CoreSettings/CoreSettings.cpp
+++ b/libraries/CoreSettings/CoreSettings.cpp
@@ -42,21 +42,26 @@ void CoreSettings::loadDefaultSounds()
   liveSettings.hum.count=1;
   liveSettings.hum.sounds[0] ="HUM_0.RAW";
 
-  liveSettings.clash.count =10 ;
+  liveSettings.clash.count = 10;
   for(int i=0; i<liveSettings.clash.count; i++)
-  { liveSettings.clash.sounds[i] = "CLASH_"+String(i+1)+"_0.RAW";
+  {
+    liveSettings.clash.sounds[i] = "CLASH_"+String(i+1)+"_0.RAW";
   }
 
-  liveSettings.swing.count = 10;
-  for(int i=0; i<liveSettings.swing.count; i++)
-  { liveSettings.swing.sounds[i] = "SWING_"+String(i+1)+"_0.RAW";
+  liveSettings.swing.count = 0;
+
+  liveSettings.smoothSwingA.count=8;
+  for(int i=0; i<liveSettings.smoothSwingA.count; i++)
+  {
+    liveSettings.smoothSwingA.sounds[i] = "SMOOTHSWINGH_"+String(i+1)+"_0.RAW";
   }
 
-  liveSettings.smoothSwingA.count=0;
-  liveSettings.smoothSwingB.count=0;
-  
+  liveSettings.smoothSwingB.count=8;
+  for(int i=0; i<liveSettings.smoothSwingB.count; i++)
+  {
+    liveSettings.smoothSwingB.sounds[i] = "SMOOTHSWINGL_"+String(i+1)+"_0.RAW";
+  }
 }
-
 
 void CoreSettings::loadDefaultColors()
 {


### PR DESCRIPTION
In case of a faulty speaker, the FW could become unresponsive. A watchdog recovery has been implemented.
The FW reboots in ARMED state, with MUTE audio.
Also, the smoothswing files are now the default.