### PR TITLE
Implement Enhancement LamaDiLuce#62 - Adjustable volume setting

### DIFF
--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -95,13 +95,13 @@ void modulesConnections()
 {
   imuModule.onSample(updateMeasurements);                   // Callback
 
-  motionModule.onMute(audioModule,audioModule.EVT_MUTE);    // Simple push connector for only one action
+  motionModule.onMute(audioModule,audioModule.EVT_VOLUME);    // Simple push connector for only one action
 
   motionModule.onArm([] (int idx, int v, int up) { // lambda function for more actions
                         ledModule.trigger(ledModule.EVT_ARM);
   });  
   motionModule.onArmed([] (int idx, int v, int up) { // lambda function for more actions
-                        if ((audioModule.state() == audioModule.IDLE) || (audioModule.state() == audioModule.MUTE))
+                        if ((audioModule.state() == audioModule.IDLE) || (audioModule.state() == audioModule.VOLUME))
                         {
                           audioModule.trigger(audioModule.EVT_ARM);
                         }
@@ -124,7 +124,7 @@ void modulesConnections()
                         ledModule.trigger(ledModule.EVT_SWING);
   });
   motionModule.onDisarm([] (int idx, int v, int up) { // lambda function for more actions
-                        if (audioModule.state() != audioModule.MUTE)
+                        if (audioModule.state() != audioModule.VOLUME)
                         {
                           audioModule.trigger(audioModule.EVT_DISARM);
                         }

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -210,7 +210,8 @@ void recovery()
   ledModule.cycle();
 
   // trigger MUTE event and cycle Motion module two times to go back in ARM
-  motionModule.trigger(motionModule.EVT_MUTE);
+  //motionModule.trigger(motionModule.EVT_MUTE);
+  audioModule.set_mute(); // Manually set to mute rather than cycling through VOLUME settings
   motionModule.cycle();
   audioModule.cycle();
   motionModule.cycle();

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -95,8 +95,10 @@ void modulesConnections()
 {
   imuModule.onSample(updateMeasurements);                   // Callback
 
-  motionModule.onMute(audioModule,audioModule.EVT_VOLUME);    // Simple push connector for only one action
-
+  motionModule.onMute([] (int idx, int v, int up) { // lambda function for more actions
+                        audioModule.trigger(audioModule.EVT_VOLUME);
+                        ledModule.reset_color_timer();
+  });  
   motionModule.onArm([] (int idx, int v, int up) { // lambda function for more actions
                         ledModule.trigger(ledModule.EVT_ARM);
   });  

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -101,7 +101,7 @@ void modulesConnections()
                         ledModule.trigger(ledModule.EVT_ARM);
   });  
   motionModule.onArmed([] (int idx, int v, int up) { // lambda function for more actions
-                        if (audioModule.state() == audioModule.IDLE)
+                        if ((audioModule.state() == audioModule.IDLE) || (audioModule.state() == audioModule.MUTE))
                         {
                           audioModule.trigger(audioModule.EVT_ARM);
                         }

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -9,7 +9,7 @@ CoreAudio& CoreAudio::begin(CoreSettings* cSet) {
   const static state_t state_table[] PROGMEM = {
     /*             ON_ENTER    ON_LOOP   ON_EXIT  EVT_MUTE  EVT_ARM  EVT_ARMED  EVT_SWING  EVT_CLASH  EVT_DISARM   ELSE */
     /*   IDLE */   ENT_IDLE, ATM_SLEEP, EXT_IDLE,     MUTE,     ARM,        -1,        -1,        -1,         -1,    -1,
-    /*   MUTE */   ENT_MUTE,        -1,       -1,       -1,      -1,        -1,        -1,        -1,       IDLE,    -1,
+    /*   MUTE */   ENT_MUTE,        -1,       -1,     MUTE,     ARM,        -1,        -1,        -1,       IDLE,    -1,
     /*    ARM */    ENT_ARM,        -1,       -1,       -1,      -1,        -1,        -1,        -1,         -1, ARMED,
     /*  ARMED */         -1,  LP_ARMED,       -1,       -1,      -1,        -1,     SWING,     CLASH,     DISARM,    -1,
     /*  CLASH */  ENT_CLASH,        -1,       -1,       -1,      -1,        -1,        -1,        -1,         -1, ARMED,
@@ -34,8 +34,8 @@ CoreAudio& CoreAudio::begin(CoreSettings* cSet) {
   patchFlashSmoothSwingBMixer = new AudioConnection(soundPlayFlashSmoothSwingBRaw, 0, mainMixer, CHANNEL_SMOOTH_SWING_B);
   patchMixerDac = new AudioConnection(mainMixer, outputDac);
   AudioMemory(AUDIO_BLOCK);
-  mainMixer.gain(CHANNEL_HUM, MAX_VOLUME); // HUM
-  mainMixer.gain(CHANNEL_FX, MAX_VOLUME);  // FX: Clash and Swing
+  mainMixer.gain(CHANNEL_HUM, volume); // HUM
+  mainMixer.gain(CHANNEL_FX, volume);  // FX: Clash and Swing
   mainMixer.gain(CHANNEL_SINE, 0);
   mainMixer.gain(CHANNEL_SMOOTH_SWING_A, 0);
   mainMixer.gain(CHANNEL_SMOOTH_SWING_B, 0);
@@ -87,14 +87,24 @@ void CoreAudio::action( int id ) {
     case EXT_IDLE:
       return;
     case ENT_MUTE:
-      beep(125, MAX_VOLUME);
-      beep(125, MAX_VOLUME);
+      volume += (MAX_VOLUME * 0.25); // Volume increases in 25% increments, giving 4 levels (25%, 50%, 75%, 100%) plus mute
+      if (volume > MAX_VOLUME) // Mute
+      {
+        beep(125, MAX_VOLUME); // Two beeps for mute
+        beep(125, MAX_VOLUME);
+        volume = 0;
+        return;
+      }
+      beep(125, volume); // One beep at current volume
       return;
     case ENT_ARM:
       useSmoothSwing = checkSmoothSwing();
-      digitalWrite(POWER_AMP_PIN, HIGH);
-      mainMixer.gain(CHANNEL_HUM, MAX_VOLUME);
-      mainMixer.gain(CHANNEL_FX, MAX_VOLUME);
+      if (volume > 0)
+      {
+        digitalWrite(POWER_AMP_PIN, HIGH);
+      }
+      mainMixer.gain(CHANNEL_HUM, volume);
+      mainMixer.gain(CHANNEL_FX, volume);
       soundPlayFlashRaw.play(moduleSettings->getRandomOnSound().c_str());
       humString = moduleSettings->getRandomHumSound();
       return;
@@ -197,9 +207,9 @@ void CoreAudio::action( int id ) {
         humVolume = 1.0 - swingStrength * MAXIMUM_HUM_DUCKING;
         swingVolumeA = swingStrength * transitionVolume;
         swingVolumeB = swingStrength * (1 - transitionVolume);
-        mainMixer.gain(CHANNEL_HUM, humVolume * MAX_VOLUME);
-        mainMixer.gain(CHANNEL_SMOOTH_SWING_A, swingVolumeA * MAX_VOLUME);
-        mainMixer.gain(CHANNEL_SMOOTH_SWING_B, swingVolumeB * MAX_VOLUME);
+        mainMixer.gain(CHANNEL_HUM, humVolume * volume);
+        mainMixer.gain(CHANNEL_SMOOTH_SWING_A, swingVolumeA * volume);
+        mainMixer.gain(CHANNEL_SMOOTH_SWING_B, swingVolumeB * volume);
         if (DEBUG_SMOOTHSWING)
         {
           CoreLogging::writeLine("%f %f %f %f %f %f %f", totalRotation, swingSpeed, swingStrength, humVolume, transitionVolume, swingVolumeA, swingVolumeB);

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -89,14 +89,16 @@ void CoreAudio::action( int id ) {
       {
         currentVolume = MAX_VOLUME;
       }
+      firstTap = true;
       return;
     case ENT_VOLUME:
       currentVolume += (MAX_VOLUME * 0.25); // Volume increases in 25% increments, giving 4 levels (25%, 50%, 75%, 100%) plus mute
-      if (currentVolume > MAX_VOLUME) // Mute
+      if (currentVolume > MAX_VOLUME || firstTap) // Mute
       {
         beep(125, MAX_VOLUME); // Two beeps for mute
         beep(125, MAX_VOLUME);
         currentVolume = 0;
+        firstTap = false;
         return;
       }
       beep(500*currentVolume, currentVolume); // One beep at current volume, varying length depending on volume setting

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -274,6 +274,11 @@ void CoreAudio::beep(int duration, float volume)
   digitalWrite(POWER_AMP_PIN, LOW);
 }
 
+void CoreAudio::set_mute()
+{
+  volume = 0;
+}
+
 void CoreAudio::setSwingSpeed(float s){
   swingSpeed = s;
 }

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -95,7 +95,7 @@ void CoreAudio::action( int id ) {
         currentVolume = 0;
         return;
       }
-      beep(125, currentVolume); // One beep at current volume
+      beep(500*currentVolume, currentVolume); // One beep at current volume, varying length depending on volume setting
       return;
     case ENT_ARM:
       useSmoothSwing = checkSmoothSwing();

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -85,6 +85,10 @@ void CoreAudio::action( int id ) {
         } 
       return;
     case EXT_IDLE:
+      if (currentVolume == 0) // If saber was muted on last disarm, set volume to max
+      {
+        currentVolume = MAX_VOLUME;
+      }
       return;
     case ENT_VOLUME:
       currentVolume += (MAX_VOLUME * 0.25); // Volume increases in 25% increments, giving 4 levels (25%, 50%, 75%, 100%) plus mute

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -38,6 +38,7 @@ class CoreAudio: public Machine {
   CoreAudio& swing( void );
   CoreAudio& clash( void );
   CoreAudio& disarm( void );
+  void set_mute();
   void beep(int duration, float volume);
   void setSwingSpeed(float s);
   void setRollSpeed(float s);

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -86,6 +86,7 @@ class CoreAudio: public Machine {
   // Params that can be tuned
   static constexpr float MAX_VOLUME = 1;                // 1 is the max volume. Use a lower number to be more quite e.g. at home
   float currentVolume = MAX_VOLUME;                            // Initial volume. Initally setting to max volume; may later load this from stored config
+  bool firstTap = true;                                 // used to check for the first tap of a mute cycle
   bool useSmoothSwing = true;                           // smoothswing is used by default of proper files are loaded. If no smoothswing are present, then the normal swing is used automatically
                                                         // SmoothSwing V2, based on Thexter's excellent work.
                                                         // For more details, see:

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -25,14 +25,14 @@
 class CoreAudio: public Machine {
 
  public:
-  enum { IDLE, MUTE, ARM, ARMED, CLASH, SWING, DISARM }; // STATES
-  enum { EVT_MUTE, EVT_ARM, EVT_ARMED, EVT_SWING, EVT_CLASH, EVT_DISARM, ELSE }; // EVENTS
+  enum { IDLE, VOLUME, ARM, ARMED, CLASH, SWING, DISARM }; // STATES
+  enum { EVT_VOLUME, EVT_ARM, EVT_ARMED, EVT_SWING, EVT_CLASH, EVT_DISARM, ELSE }; // EVENTS
   CoreAudio( void ) : Machine() {};
   CoreAudio& begin( CoreSettings* cSet );
   CoreAudio& trace( Stream & stream );
   CoreAudio& trigger( int event );
   int state( void );
-  CoreAudio& mute( void );
+  CoreAudio& volume( void );
   CoreAudio& arm( void );
   CoreAudio& armed( void );
   CoreAudio& swing( void );
@@ -46,7 +46,7 @@ class CoreAudio: public Machine {
   bool checkSmoothSwing( void );
 
  private:
-  enum { ENT_IDLE, LP_IDLE, EXT_IDLE, ENT_MUTE, ENT_ARM, LP_ARMED, ENT_CLASH, ENT_SWING, LP_SWING, ENT_DISARM }; // ACTIONS
+  enum { ENT_IDLE, LP_IDLE, EXT_IDLE, ENT_VOLUME, ENT_ARM, LP_ARMED, ENT_CLASH, ENT_SWING, LP_SWING, ENT_DISARM }; // ACTIONS
   int event( int id ); 
   void action( int id );
   void resetSmoothSwing( void );
@@ -85,7 +85,7 @@ class CoreAudio: public Machine {
   bool powerSwing = false;
   // Params that can be tuned
   static constexpr float MAX_VOLUME = 1;                // 1 is the max volume. Use a lower number to be more quite e.g. at home
-  float volume = MAX_VOLUME;                            // Initial volume. Initally setting to max volume; may later load this from stored config
+  float currentVolume = MAX_VOLUME;                            // Initial volume. Initally setting to max volume; may later load this from stored config
   bool useSmoothSwing = true;                           // smoothswing is used by default of proper files are loaded. If no smoothswing are present, then the normal swing is used automatically
                                                         // SmoothSwing V2, based on Thexter's excellent work.
                                                         // For more details, see:
@@ -109,12 +109,12 @@ Automaton::ATML::begin - Automaton Markup Language
   <machine name="CoreAudio">
     <states>
       <IDLE index="0" sleep="1" on_enter="ENT_IDLE" on_loop="LP_IDLE" on_exit="EXT_IDLE">
-        <EVT_MUTE>MUTE</EVT_MUTE>
+        <EVT_VOLUME>VOLUME</EVT_VOLUME>
         <EVT_ARM>ARM</EVT_ARM>
       </IDLE>
-      <MUTE index="1" on_enter="ENT_MUTE">
+      <VOLUME index="1" on_enter="ENT_VOLUME">
         <EVT_DISARM>IDLE</EVT_DISARM>
-      </MUTE>
+      </VOLUME>
       <ARM index="2" on_enter="ENT_ARM">
         <ELSE>ARMED</ELSE>
       </ARM>
@@ -136,7 +136,7 @@ Automaton::ATML::begin - Automaton Markup Language
       </DISARM>
     </states>
     <events>
-      <EVT_MUTE index="0" access="MIXED"/>
+      <EVT_VOLUME index="0" access="MIXED"/>
       <EVT_ARM index="1" access="MIXED"/>
       <EVT_ARMED index="2" access="MIXED"/>
       <EVT_SWING index="3" access="MIXED"/>

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -84,6 +84,7 @@ class CoreAudio: public Machine {
   bool powerSwing = false;
   // Params that can be tuned
   static constexpr float MAX_VOLUME = 1;                // 1 is the max volume. Use a lower number to be more quite e.g. at home
+  float volume = MAX_VOLUME;                            // Initial volume. Initally setting to max volume; may later load this from stored config
   bool useSmoothSwing = true;                           // smoothswing is used by default of proper files are loaded. If no smoothswing are present, then the normal swing is used automatically
                                                         // SmoothSwing V2, based on Thexter's excellent work.
                                                         // For more details, see:

--- a/libraries/CoreLed/CoreLed.cpp
+++ b/libraries/CoreLed/CoreLed.cpp
@@ -285,6 +285,11 @@ CoreLed& CoreLed::disarm() {
   return *this;
 }
 
+void CoreLed::reset_color_timer()
+{
+  timer_color_selection.setFromNow(this,TIME_FOR_START_COLOR_SELECTION);
+}
+
 /*
  * onArm() push connector variants ( slots 1, autostore 0, broadcast 0 )
  */

--- a/libraries/CoreLed/CoreLed.h
+++ b/libraries/CoreLed/CoreLed.h
@@ -35,6 +35,7 @@ class CoreLed: public Machine {
   CoreLed& swing( void );
   CoreLed& clash( void );
   CoreLed& disarm( void );
+  void reset_color_timer();
 
  private:
   enum { ENT_IDLE, LP_IDLE, ENT_RECHARGE, LP_RECHARGE, ENT_ARM, LP_ARM, EXT_ARM, ENT_ARMED, ENT_CLASH, ENT_SWING, ENT_DISARM }; // ACTIONS

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -7,14 +7,14 @@
 CoreMotion& CoreMotion::begin() {
   // clang-format off
   const static state_t state_table[] PROGMEM = {
-    /*             ON_ENTER    ON_LOOP  ON_EXIT  EVT_MUTE  EVT_DISARM  EVT_SWING  EVT_CLASH  EVT_ARMED  EVT_ARM   ELSE */
+    /*             ON_ENTER    ON_LOOP  ON_EXIT  EVT_VOLUME  EVT_DISARM  EVT_SWING  EVT_CLASH  EVT_ARMED  EVT_ARM   ELSE */
     /*   IDLE */   ENT_IDLE,   LP_IDLE,      -1,       -1,         -1,        -1,        -1,        -1,     ARM,    -1,
-    /*    ARM */    ENT_ARM,    LP_ARM,      -1,     MUTE,         -1,        -1,        -1,     ARMED,      -1,    -1,
+    /*    ARM */    ENT_ARM,    LP_ARM,      -1,     VOLUME,         -1,        -1,        -1,     ARMED,      -1,    -1,
     /*  ARMED */  ENT_ARMED,  LP_ARMED,      -1,       -1,     DISARM,     SWING,     CLASH,        -1,      -1,    -1,
     /* DISARM */ ENT_DISARM,        -1,      -1,       -1,       IDLE,     ARMED,        -1,        -1,      -1,    -1,
     /*  CLASH */  ENT_CLASH,        -1,      -1,       -1,         -1,        -1,        -1,        -1,      -1, ARMED,
     /*  SWING */  ENT_SWING,        -1,      -1,       -1,         -1,        -1,     CLASH,     ARMED,      -1,    -1,
-    /*   MUTE */   ENT_MUTE,        -1,      -1,       -1,         -1,        -1,        -1,        -1,      -1,   ARM,
+    /*   VOLUME */   ENT_VOLUME,        -1,      -1,       -1,         -1,        -1,        -1,        -1,      -1,   ARM,
   };
   // clang-format on
   Machine::begin( state_table, ELSE );
@@ -27,7 +27,7 @@ CoreMotion& CoreMotion::begin() {
 
 int CoreMotion::event( int id ) {
   switch ( id ) {
-    case EVT_MUTE:
+    case EVT_VOLUME:
       return ( int1Status > 0 );
     case EVT_DISARM:
       return timer_horizontal.expired( this );
@@ -110,7 +110,7 @@ void CoreMotion::action( int id ) {
       timer_arm.set(0); // otherwise there is a delay in triggering the ARMED event. This should be not needed. To be investigated.
       push( connectors, ON_SWING, 0, 0, 0 );
       return;
-    case ENT_MUTE:
+    case ENT_VOLUME:
       int1Status = 0;
       push( connectors, ON_MUTE, 0, 0, 0 );
       return;
@@ -178,8 +178,8 @@ int CoreMotion::state( void ) {
  *
  */
 
-CoreMotion& CoreMotion::mute() {
-  trigger( EVT_MUTE );
+CoreMotion& CoreMotion::volume() {
+  trigger( EVT_VOLUME );
   return *this;
 }
 

--- a/libraries/CoreMotion/CoreMotion.h
+++ b/libraries/CoreMotion/CoreMotion.h
@@ -6,8 +6,8 @@
 class CoreMotion: public Machine {
 
  public:
-  enum { IDLE, ARM, ARMED, DISARM, CLASH, SWING, MUTE }; // STATES
-  enum { EVT_MUTE, EVT_DISARM, EVT_SWING, EVT_CLASH, EVT_ARMED, EVT_ARM, ELSE }; // EVENTS
+  enum { IDLE, ARM, ARMED, DISARM, CLASH, SWING, VOLUME }; // STATES
+  enum { EVT_VOLUME, EVT_DISARM, EVT_SWING, EVT_CLASH, EVT_ARMED, EVT_ARM, ELSE }; // EVENTS
   CoreMotion( void ) : Machine() {};
   CoreMotion& begin( void );
   CoreMotion& trace( Stream & stream );
@@ -27,7 +27,7 @@ class CoreMotion: public Machine {
   CoreMotion& onMute( atm_cb_push_t callback, int idx = 0 );
   CoreMotion& onSwing( Machine& machine, int event = 0 );
   CoreMotion& onSwing( atm_cb_push_t callback, int idx = 0 );
-  CoreMotion& mute( void );
+  CoreMotion& volume( void );
   CoreMotion& disarm( void );
   CoreMotion& swing( void );
   CoreMotion& clash( void );
@@ -44,7 +44,7 @@ class CoreMotion: public Machine {
   void incInt1Status( void );
 
  private:
-  enum { ENT_IDLE, LP_IDLE, ENT_ARM, LP_ARM, ENT_ARMED, LP_ARMED, ENT_DISARM, LP_DISARM, ENT_CLASH, ENT_SWING, ENT_MUTE }; // ACTIONS
+  enum { ENT_IDLE, LP_IDLE, ENT_ARM, LP_ARM, ENT_ARMED, LP_ARMED, ENT_DISARM, LP_DISARM, ENT_CLASH, ENT_SWING, ENT_VOLUME }; // ACTIONS
   enum { ON_ARM, ON_ARMED, ON_CLASH, ON_DISARM, ON_IDLE, ON_MUTE, ON_SWING, CONN_MAX }; // CONNECTORS
   atm_connector connectors[CONN_MAX];
   int event( int id ); 
@@ -87,7 +87,7 @@ Automaton::ATML::begin - Automaton Markup Language
         <EVT_ARM>ARM</EVT_ARM>
       </IDLE>
       <ARM index="1" on_enter="ENT_ARM" on_loop="LP_ARM">
-        <EVT_MUTE>MUTE</EVT_MUTE>
+        <EVT_VOLUME>VOLUME</EVT_VOLUME>
         <EVT_ARMED>ARMED</EVT_ARMED>
       </ARM>
       <ARMED index="2" on_enter="ENT_ARMED" on_loop="LP_ARMED">
@@ -106,12 +106,12 @@ Automaton::ATML::begin - Automaton Markup Language
         <EVT_CLASH>CLASH</EVT_CLASH>
         <EVT_ARMED>ARMED</EVT_ARMED>
       </SWING>
-      <MUTE index="6" on_enter="ENT_MUTE">
+      <VOLUME index="6" on_enter="ENT_VOLUME">
         <ELSE>ARM</ELSE>
-      </MUTE>
+      </VOLUME>
     </states>
     <events>
-      <EVT_MUTE index="0" access="MIXED"/>
+      <EVT_VOLUME index="0" access="MIXED"/>
       <EVT_DISARM index="1" access="MIXED"/>
       <EVT_SWING index="2" access="MIXED"/>
       <EVT_CLASH index="3" access="MIXED"/>
@@ -124,7 +124,7 @@ Automaton::ATML::begin - Automaton Markup Language
       <CLASH autostore="0" broadcast="0" dir="PUSH" slots="1"/>
       <DISARM autostore="0" broadcast="0" dir="PUSH" slots="1"/>
       <IDLE autostore="0" broadcast="0" dir="PUSH" slots="1"/>
-      <MUTE autostore="0" broadcast="0" dir="PUSH" slots="1"/>
+      <VOLUME autostore="0" broadcast="0" dir="PUSH" slots="1"/>
       <SWING autostore="0" broadcast="0" dir="PUSH" slots="1"/>
     </connectors>
     <methods>


### PR DESCRIPTION
### Overview
This change allows you to cycle the saber's volume setting in 25% increments during arming. Resolves LamaDiLuce#62.

### Usage
When the saber first arms, the volume is set to maximum. One tap will set it to mute (the same as before). Each additional tap will increase the volume by 25% until the maximum is reached. When the volume is at maximum, another tap will mute it.

The volume setting will persist until the saber is next reset (i.e., the switch is turned off). A possible future enhancement would be to save the setting to flash memory and load it after a reset. But this seemed like a lot of additional work for minimal gain to me. :)

### Audio Feedback
When the volume is cycled to mute, the saber will beep twice (the same as before). After it is cycled to a new volume, it will beep once at the new volume.

### Technical Notes
I've implemented this change using only a single Automaton state, the one that was previously called `MUTE`. I have renamed it to `VOLUME` for clarity. This seemed more economical and easier to introduce, rather than adding additional machine states for the different volume settings.

This also changes the state flows slightly. Instead of only being able to go from `IDLE` to `MUTE` and back to `IDLE`, the Audio module can now also go from `IDLE` to `VOLUME` to `ARM`.

The volume is tracked in `float currentVolume`, with 0 being mute and 1 being the maximum. `MAX_VOLUME` is still present and still respected if a user alters it. The volume settings are calculated using 25% of `MAX_VOLUME`, which by default is still 1. 

If `currentVolume` is 0 during the `ARM` stage, the speaker pin will not be powered. Otherwise there was a slight but noticeable buzz from the speaker.

I also had to add an additional method called `CoreAudio::set_mute()`. This will manually set `currentVolume` to 0 (mute), and is currently only used in recovery.