### PR TITLE
FEATURE(Motion): Free arm position

### DIFF
--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -138,6 +138,12 @@ void modulesConnections()
                         audioModule.trigger(audioModule.EVT_DISARM);
                         ledModule.trigger(ledModule.EVT_DISARM);
   });
+  ledModule.onNextcolor([] (int idx, int v, int up) { // lambda function for more actions
+                        if (v == 0)
+                        {
+                          audioModule.beep(125, 1);
+                        }
+  });
 }
 
 void updateMeasurements(int idx, int v, int up)

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -138,12 +138,6 @@ void modulesConnections()
                         audioModule.trigger(audioModule.EVT_DISARM);
                         ledModule.trigger(ledModule.EVT_DISARM);
   });
-  ledModule.onNextcolor([] (int idx, int v, int up) { // lambda function for more actions
-                        if (v == 0)
-                        {
-                          audioModule.beep(125, 1);
-                        }
-  });
 }
 
 void updateMeasurements(int idx, int v, int up)

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -75,7 +75,8 @@ void CoreMotion::action( int id ) {
       return;
     case LP_ARM:
       if (
-          (AccelZ > (VERTICAL_POSITION - TOLERANCE_POSITION))
+          (AccelZ > (VERTICAL_POSITION - TOLERANCE_POSITION) || 
+          (swingSpeed > SWING_THRESHOLD))
          )
       {
         timer_arm.setFromNow(this,TIME_FOR_CONFIRM_ARM);

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -42,6 +42,7 @@ int CoreMotion::event( int id ) {
              (rollSpeed < ROLL_SPEED_THRESHOLD_LOW));
     case EVT_ARM:
       return (
+              timer_no_swing.expired(this) &&
               (abs(GyroZ) > ARM_THRESHOLD_Z) &&
               ((digitalRead(USB_PIN) == LOW) || DEBUG)
              );
@@ -68,6 +69,10 @@ void CoreMotion::action( int id ) {
       push( connectors, ON_IDLE, 0, 0, 0 );
       return;
     case LP_IDLE:
+      if (swingSpeed > SWING_THRESHOLD)
+      {
+        timer_no_swing.setFromNow(this,TIME_FOR_START_ARM);
+      }
       return;
     case ENT_ARM:
       int1Status = 0;

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -28,7 +28,7 @@ CoreMotion& CoreMotion::begin() {
 int CoreMotion::event( int id ) {
   switch ( id ) {
     case EVT_MUTE:
-      return ( int1Status > 0 );
+      return AccelZ > (VERTICAL_POSITION - TOLERANCE_POSITION) && int1Status > 0;
     case EVT_DISARM:
       return timer_horizontal.expired( this );
     case EVT_SWING:

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -37,15 +37,12 @@ int CoreMotion::event( int id ) {
     case EVT_CLASH:
       return ( int1Status > 0 );
     case EVT_ARMED:
-      return (timer_arm.expired(this) &&
-             (swingSpeed < SWING_THRESHOLD) &&
-             (rollSpeed < ROLL_SPEED_THRESHOLD_LOW));
+      return timer_arm.expired(this);
     case EVT_ARM:
-      return (timer_vertical.expired( this ) && 
-             (abs(GyroZ) > ARM_THRESHOLD_Z) &&
-             (GyroX < ARM_THRESHOLD_XY) &&
-             (GyroY < ARM_THRESHOLD_XY) &&
-             ((digitalRead(USB_PIN) == LOW) || DEBUG));
+      return (
+              (abs(GyroZ) > ARM_THRESHOLD_Z) &&
+              ((digitalRead(USB_PIN) == LOW) || DEBUG)
+             );
   }
   return 0;
 }
@@ -69,20 +66,15 @@ void CoreMotion::action( int id ) {
       push( connectors, ON_IDLE, 0, 0, 0 );
       return;
     case LP_IDLE:
-      if ((AccelZ < (VERTICAL_POSITION - TOLERANCE_POSITION)) || 
-          (AccelZ > (VERTICAL_POSITION + TOLERANCE_POSITION)))
-      {
-        timer_vertical.setFromNow(this,TIME_FOR_START_ARM);
-      }
       return;
     case ENT_ARM:
       int1Status = 0;
       push( connectors, ON_ARM, 0, 0, 0 );
       return;
     case LP_ARM:
-      if ((AccelZ < (ARM_POSITION - TOLERANCE_POSITION)) || 
-          (AccelZ > (ARM_POSITION + TOLERANCE_POSITION)) || 
-          (swingSpeed > SWING_THRESHOLD))
+      if (
+          (AccelZ > (VERTICAL_POSITION - TOLERANCE_POSITION))
+         )
       {
         timer_arm.setFromNow(this,TIME_FOR_CONFIRM_ARM);
       }

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -37,7 +37,9 @@ int CoreMotion::event( int id ) {
     case EVT_CLASH:
       return ( int1Status > 0 );
     case EVT_ARMED:
-      return timer_arm.expired(this);
+      return (timer_arm.expired(this) &&
+             (swingSpeed < SWING_THRESHOLD) &&
+             (rollSpeed < ROLL_SPEED_THRESHOLD_LOW));
     case EVT_ARM:
       return (
               (abs(GyroZ) > ARM_THRESHOLD_Z) &&

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -43,7 +43,10 @@ int CoreMotion::event( int id ) {
     case EVT_ARM:
       return (
               timer_no_swing.expired(this) &&
-              (abs(GyroZ) > ARM_THRESHOLD_Z) &&
+              (
+                (AccelZ > (VERTICAL_POSITION - TOLERANCE_POSITION) && abs(GyroZ) > ARM_THRESHOLD_Z) ||
+                abs(GyroZ) > ARM_ALT_THRESHOLD_Z
+              ) &&
               ((digitalRead(USB_PIN) == LOW) || DEBUG)
              );
   }

--- a/libraries/CoreMotion/CoreMotion.h
+++ b/libraries/CoreMotion/CoreMotion.h
@@ -64,7 +64,8 @@ class CoreMotion: public Machine {
   static constexpr int SWING_THRESHOLD = 80;
   static constexpr int ROLL_SPEED_THRESHOLD_LOW = 40;
   static constexpr int ROLL_SPEED_THRESHOLD_HIGH = 150;
-  static constexpr int ARM_THRESHOLD_Z = 1000;
+  static constexpr int ARM_THRESHOLD_Z = 300;
+  static constexpr int ARM_ALT_THRESHOLD_Z = 1000;
   static constexpr int ARM_THRESHOLD_XY = 100;
   static constexpr float VERTICAL_POSITION = 8.0;
   static constexpr float HORIZONTAL_POSITION = 0.0;

--- a/libraries/CoreMotion/CoreMotion.h
+++ b/libraries/CoreMotion/CoreMotion.h
@@ -67,7 +67,6 @@ class CoreMotion: public Machine {
   static constexpr int ARM_THRESHOLD_Z = 1000;
   static constexpr int ARM_THRESHOLD_XY = 100;
   static constexpr float VERTICAL_POSITION = 8.0;
-  static constexpr float ARM_POSITION = -6.0;
   static constexpr float HORIZONTAL_POSITION = 0.0;
   static constexpr float TOLERANCE_POSITION = 2;
   static constexpr int TIME_FOR_START_ARM = 500;

--- a/libraries/CoreMotion/CoreMotion.h
+++ b/libraries/CoreMotion/CoreMotion.h
@@ -64,7 +64,7 @@ class CoreMotion: public Machine {
   static constexpr int SWING_THRESHOLD = 80;
   static constexpr int ROLL_SPEED_THRESHOLD_LOW = 40;
   static constexpr int ROLL_SPEED_THRESHOLD_HIGH = 150;
-  static constexpr int ARM_THRESHOLD_Z = 300;
+  static constexpr int ARM_THRESHOLD_Z = 1000;
   static constexpr int ARM_THRESHOLD_XY = 100;
   static constexpr float VERTICAL_POSITION = 8.0;
   static constexpr float ARM_POSITION = -6.0;

--- a/libraries/CoreMotion/CoreMotion.h
+++ b/libraries/CoreMotion/CoreMotion.h
@@ -49,7 +49,7 @@ class CoreMotion: public Machine {
   atm_connector connectors[CONN_MAX];
   int event( int id ); 
   void action( int id );
-  atm_timer_millis timer_vertical;
+  atm_timer_millis timer_no_swing;
   atm_timer_millis timer_horizontal;
   atm_timer_millis timer_arm;
   float AccelX;


### PR DESCRIPTION
With this feature the user can turn on the saber from any position. 

### Compatibility with original turn on method
When saber is in vertical position it applies the original roll sensibility and wait to config or confirm arm when saber is at non-vertical position and is not swinging.

### How to use
As alternative, the user can turn on the saber from any non-vertical position with hard roll (it has less sensibility), with this method it confirm turn on instantly

### ¿Why?
This allows turn on the saber faster and more comfortably, and also allows whoever uses saberstaff turn on both parts at the same time.