### PR TITLE
Battery monitor

### DIFF
--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -25,7 +25,7 @@ CoreSettings settingsModule;
 void setup()
 {
   modulesInit();
-  
+    
   modulesConnections();
 
   attachInterrupt(digitalPinToInterrupt(imuModule.getInt1Pin()), int1ISR, RISING);
@@ -39,6 +39,8 @@ void setup()
   {
     audioModule.beep(100, 0.1);
   }
+
+  initBattery();
 
   initWatchdog();
 }
@@ -74,10 +76,10 @@ void modulesInit()
   CoreSettings* setPtr;
   setPtr = &settingsModule;
 
-  audioModule.trace(Serial);
+  //audioModule.trace(Serial);
   audioModule.begin(setPtr);
 
-  motionModule.trace(Serial);
+  //motionModule.trace(Serial);
   motionModule.begin();
 
   settingsModule.init();
@@ -223,4 +225,15 @@ void recovery()
   motionModule.cycle();
   audioModule.cycle();
   ledModule.cycle();
+}
+
+void initBattery()
+{
+  analogReference(EXTERNAL);
+  analogReadResolution(12);
+  analogReadAveraging(32);
+  if (digitalRead(USB_PIN) == LOW)
+  {
+    ledModule.batteryCheck();
+  }
 }

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -27,7 +27,6 @@ void setup()
 {
   modulesInit();
 
-  initBattery();
     
   modulesConnections();
 
@@ -43,6 +42,8 @@ void setup()
     audioModule.beep(100, 0.1);
   }
 
+  initBattery();
+
   initWatchdog();
 
   batteryCheckTime = millis();
@@ -55,11 +56,16 @@ void loop()
   if (millis() - batteryCheckTime > 10000)
   {
     if (analogRead(39) > ANALOG_REF_BATTERY_DEPLETED)
-    {      
-      audioModule.beep(100, 1);
-      audioModule.beep(100, 1);
-      audioModule.beep(100, 1);
-      motionModule.trigger(motionModule.EVT_DISARM);
+    {
+      if (motionModule.state() == motionModule.ARMED)
+      {
+        audioModule.treeplebeep(125, 1);
+        motionModule.trigger(motionModule.EVT_DISARM);
+      }
+      else if (motionModule.state() == motionModule.IDLE)
+      {
+        ledModule.pulse({255,0,0,0}); // RED
+      }
     }    
     batteryCheckTime = millis();
   }
@@ -249,25 +255,18 @@ void initBattery()
   analogReadResolution(12);
   analogReadAveraging(32);
 
-  if (digitalRead(USB_PIN) == LOW)
-  {
-    delay(200);
-
+  // if (digitalRead(USB_PIN) == LOW)
+  // {
+    delay(100);
     int analogRef = analogRead(39); // this values goes from ~ 1470 at full battery to ~ 2000 at depleted battery. It's not linear.
     CoreLogging::writeLine("Analog read: %d", analogRef);
     if (analogRef > ANALOG_REF_BATTERY_DEPLETED)
     {
-      audioModule.beep(100, 1);
-      audioModule.beep(100, 1);
-      audioModule.beep(100, 1);
-      while (true)
-      {
-        // I know this is very sad, the best way would be to put all state machines in deep sleep. TODO
-      }
+      ledModule.pulse({255,0,0,0}); // RED
     }
     else if (analogRef > ANALOG_REF_BATTERY_LOW)
     {
-      ledModule.pulse({255,0,0,0}); // RED
+      ledModule.pulse({0,0,0,255}); // WHITE
     }
-  }
+  // }
 }

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -53,7 +53,7 @@ void loop()
 {
   refreshWatchdog();
 
-  if (millis() - batteryCheckTime > 10000)
+  if (millis() - batteryCheckTime > 30000)
   {
     if (analogRead(39) > ANALOG_REF_BATTERY_DEPLETED)
     {

--- a/CoreEntryPoint/CoreEntryPoint.ino
+++ b/CoreEntryPoint/CoreEntryPoint.ino
@@ -11,7 +11,7 @@
 #include "CoreImu.h"
 #include "CoreMotion.h"
 
-#define BUILD "2.2.7"
+#define BUILD "3.0.0"
 
 // Modules
 String incomingMessage;

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -272,6 +272,8 @@ void CoreAudio::resetSmoothSwing()
 
 void CoreAudio::beep(int duration, float volume)
 {
+  soundPlayFlashFXRaw.stop();
+  soundPlayFlashRaw.stop();
   digitalWrite(POWER_AMP_PIN, HIGH);
   delay(50);
   mainMixer.gain(CHANNEL_SINE, volume);
@@ -283,6 +285,27 @@ void CoreAudio::beep(int duration, float volume)
 void CoreAudio::set_mute()
 {
   currentVolume = 0;
+}
+
+void CoreAudio::treeplebeep(int duration, float volume)
+{
+  soundPlayFlashFXRaw.stop();
+  soundPlayFlashRaw.stop();
+  delay(100);
+  digitalWrite(POWER_AMP_PIN, HIGH);
+  delay(50);
+  mainMixer.gain(CHANNEL_SINE, volume);
+  delay(duration);
+  mainMixer.gain(CHANNEL_SINE, 0);
+  delay(50);
+  mainMixer.gain(CHANNEL_SINE, volume);
+  delay(duration);
+  mainMixer.gain(CHANNEL_SINE, 0);
+  delay(50);
+  mainMixer.gain(CHANNEL_SINE, volume);
+  delay(duration);
+  mainMixer.gain(CHANNEL_SINE, 0);
+  digitalWrite(POWER_AMP_PIN, LOW);
 }
 
 void CoreAudio::setSwingSpeed(float s){

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -40,6 +40,7 @@ class CoreAudio: public Machine {
   CoreAudio& disarm( void );
   void set_mute();
   void beep(int duration, float volume);
+  void treeplebeep(int duration, float volume);
   void setSwingSpeed(float s);
   void setRollSpeed(float s);
   void setAngDotProduct(float s);

--- a/libraries/CoreCommon/CoreCommon.h
+++ b/libraries/CoreCommon/CoreCommon.h
@@ -3,6 +3,9 @@
 static constexpr bool DEBUG = false;
 static constexpr bool DEBUG_SMOOTHSWING = false;
 
+static constexpr int ANALOG_REF_BATTERY_LOW = 1480;  // max 1 hour of battery left
+static constexpr int ANALOG_REF_BATTERY_DEPLETED = 1763; // safe threshold to avoid under discharge
+
 // LED RGBW
 #define PIN_RED 3
 #define PIN_GREEN 4

--- a/libraries/CoreCommon/CoreCommon.h
+++ b/libraries/CoreCommon/CoreCommon.h
@@ -3,7 +3,7 @@
 static constexpr bool DEBUG = false;
 static constexpr bool DEBUG_SMOOTHSWING = false;
 
-static constexpr int ANALOG_REF_BATTERY_LOW = 1480;  // max 1 hour of battery left
+static constexpr int ANALOG_REF_BATTERY_LOW = 1490;  // max 1 hour of battery left
 static constexpr int ANALOG_REF_BATTERY_DEPLETED = 1763; // safe threshold to avoid under discharge
 
 // LED RGBW

--- a/libraries/CoreLed/CoreLed.cpp
+++ b/libraries/CoreLed/CoreLed.cpp
@@ -224,6 +224,27 @@ void CoreLed::fadeOut()
   }
 }
 
+void CoreLed::batteryCheck()
+{
+  // inspired by https://forum.pjrc.com/threads/26117-Teensy-3-1-Voltage-sensing-and-low-battery-alert
+  uint32_t analogRef = analogRead(39); // this values goes from ~ 1470 at full battery to ~ 2000 at depleted battery. It's not linear.
+
+  if (analogRef < 1480) // full battery
+  {
+    changeColor({0,255,0,0}); // GREEN
+  }
+  else if (analogRef < 1560) // less then 1 hour of battery
+  {
+    changeColor({255,255,0,0}); // ORANGE
+  }
+  else // battery depleted
+  {
+    changeColor({255,0,0,0}); // RED
+  }
+
+  delay(CHARGE_SEQUENCE_BLINK_TIME);
+  turnOff();
+}
 
 /* Optionally override the default trigger() method
  * Control how your machine processes triggers

--- a/libraries/CoreLed/CoreLed.cpp
+++ b/libraries/CoreLed/CoreLed.cpp
@@ -71,6 +71,7 @@ void CoreLed::action( int id ) {
   switch ( id ) {
     case ENT_IDLE:
       turnOff();
+      batteryCharged = false;
       return;
     case LP_IDLE:
       return;
@@ -85,19 +86,21 @@ void CoreLed::action( int id ) {
       delay(CHARGE_SEQUENCE_BLINK_TIME);
       turnOff();
       timer_blink.setFromNow(this,BLINK_RECHARGE_STATUS_TIMER);
+      batteryCharged = false;
       return;
     case LP_RECHARGE:
       if (timer_blink.expired( this ))
       {
-        if (digitalRead(CHARGE_PIN) == LOW)
+        if (digitalRead(STANDBY_PIN) == LOW || batteryCharged)
+        {
+          batteryCharged = true;
+          pulse({0,0,255,0}); // BLUE
+          timer_blink.setFromNow(this,BLINK_RECHARGED_STATUS_TIMER);
+        }
+        else if (digitalRead(CHARGE_PIN) == LOW)
         {
           pulse({255,0,0,0}); // RED
           timer_blink.setFromNow(this,BLINK_RECHARGE_STATUS_TIMER);
-        }
-        if (digitalRead(STANDBY_PIN) == LOW)
-        {
-          pulse({0,0,255,0}); // BLUE
-          timer_blink.setFromNow(this,BLINK_RECHARGED_STATUS_TIMER);
         }
       }
       return;

--- a/libraries/CoreLed/CoreLed.cpp
+++ b/libraries/CoreLed/CoreLed.cpp
@@ -91,16 +91,12 @@ void CoreLed::action( int id ) {
       {
         if (digitalRead(CHARGE_PIN) == LOW)
         {
-          changeColor({255,0,0,0}); // RED
-          delay(RECHARGING_BLINK_TIME);
-          turnOff();
+          pulse({255,0,0,0}); // RED
           timer_blink.setFromNow(this,BLINK_RECHARGE_STATUS_TIMER);
         }
         if (digitalRead(STANDBY_PIN) == LOW)
         {
-          changeColor({0,0,255,0}); // BLUE
-          delay(RECHARGING_BLINK_TIME);
-          turnOff();
+          pulse({0,0,255,0}); // BLUE
           timer_blink.setFromNow(this,BLINK_RECHARGED_STATUS_TIMER);
         }
       }
@@ -212,7 +208,7 @@ void CoreLed::fadeIn()
 
 void CoreLed::fadeOut()
 {
-  CoreLogging::writeLine("CoreLed: FadeIn");
+  CoreLogging::writeLine("CoreLed: FadeOut");
   for (int i = FADE_DELAY; i >= 0; i--)
   {
     singleStepColor.red = mainColor.red / FADE_DELAY * i;
@@ -224,26 +220,26 @@ void CoreLed::fadeOut()
   }
 }
 
-void CoreLed::batteryCheck()
+void CoreLed::pulse(const ColorLed& cLed)
 {
-  // inspired by https://forum.pjrc.com/threads/26117-Teensy-3-1-Voltage-sensing-and-low-battery-alert
-  uint32_t analogRef = analogRead(39); // this values goes from ~ 1470 at full battery to ~ 2000 at depleted battery. It's not linear.
-
-  if (analogRef < 1480) // full battery
+  for (int i = 0; i <= PULSE_DELAY; i++)
   {
-    changeColor({0,255,0,0}); // GREEN
+    singleStepColor.red = cLed.red / PULSE_DELAY * i;
+    singleStepColor.green = cLed.green / PULSE_DELAY * i;
+    singleStepColor.blue = cLed.blue / PULSE_DELAY * i;
+    singleStepColor.white = cLed.white / PULSE_DELAY * i;
+    changeColor(singleStepColor);
+    delay(PULSE_TIME / 2 / PULSE_DELAY);
   }
-  else if (analogRef < 1560) // less then 1 hour of battery
+  for (int i = FADE_DELAY; i >= 0; i--)
   {
-    changeColor({255,255,0,0}); // ORANGE
+    singleStepColor.red = cLed.red / PULSE_DELAY * i;
+    singleStepColor.green = cLed.green / PULSE_DELAY * i;
+    singleStepColor.blue = cLed.blue / PULSE_DELAY * i;
+    singleStepColor.white = cLed.white / PULSE_DELAY * i;
+    changeColor(singleStepColor);
+    delay(PULSE_TIME / 2 / PULSE_DELAY);
   }
-  else // battery depleted
-  {
-    changeColor({255,0,0,0}); // RED
-  }
-
-  delay(CHARGE_SEQUENCE_BLINK_TIME);
-  turnOff();
 }
 
 /* Optionally override the default trigger() method

--- a/libraries/CoreLed/CoreLed.h
+++ b/libraries/CoreLed/CoreLed.h
@@ -36,6 +36,7 @@ class CoreLed: public Machine {
   CoreLed& clash( void );
   CoreLed& disarm( void );
   void reset_color_timer();
+  void batteryCheck( void );
 
  private:
   enum { ENT_IDLE, LP_IDLE, ENT_RECHARGE, LP_RECHARGE, ENT_ARM, LP_ARM, EXT_ARM, ENT_ARMED, ENT_CLASH, ENT_SWING, ENT_DISARM }; // ACTIONS

--- a/libraries/CoreLed/CoreLed.h
+++ b/libraries/CoreLed/CoreLed.h
@@ -76,6 +76,7 @@ class CoreLed: public Machine {
   static constexpr int PULSE_TIME = 500;
   CoreSettings* moduleSettings;
   int numberOfColorChanged = 0;
+  bool batteryCharged = false;
 };
 
 /* 

--- a/libraries/CoreLed/CoreLed.h
+++ b/libraries/CoreLed/CoreLed.h
@@ -37,6 +37,7 @@ class CoreLed: public Machine {
   CoreLed& disarm( void );
   void reset_color_timer();
   void batteryCheck( void );
+  void pulse(const ColorLed& cLed);
 
  private:
   enum { ENT_IDLE, LP_IDLE, ENT_RECHARGE, LP_RECHARGE, ENT_ARM, LP_ARM, EXT_ARM, ENT_ARMED, ENT_CLASH, ENT_SWING, ENT_DISARM }; // ACTIONS
@@ -71,6 +72,8 @@ class CoreLed: public Machine {
   static constexpr int FADE_DELAY = 30;
   static constexpr int FADE_IN_TIME = 300;
   static constexpr int FADE_OUT_TIME = 1000;
+  static constexpr int PULSE_DELAY = 30;
+  static constexpr int PULSE_TIME = 500;
   CoreSettings* moduleSettings;
   int numberOfColorChanged = 0;
 };


### PR DESCRIPTION
With this PR there are two new behaviors according to the remaining charge of the battery:
- Battery running low (max 1 hour of usage) --> the blade flashes WHITE when the switch is moved to the ON position
- Battery completely discharged --> the blade flashes RED when the switch is moved to the ON position. If the battery reaches this status during combat, the saber disarms and makes three beeps.