### PR TITLE
Feature: turn off from arm state, cancelling color and volume selection

### DIFF
--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -10,7 +10,7 @@ CoreAudio& CoreAudio::begin(CoreSettings* cSet) {
     /*             ON_ENTER    ON_LOOP   ON_EXIT  EVT_VOLUME  EVT_ARM  EVT_ARMED  EVT_SWING  EVT_CLASH  EVT_DISARM   ELSE */
     /*   IDLE */   ENT_IDLE, ATM_SLEEP, EXT_IDLE,     VOLUME,     ARM,        -1,        -1,        -1,         -1,    -1,
     /*   VOLUME */   ENT_VOLUME,        -1,       -1,     VOLUME,     ARM,        -1,        -1,        -1,       IDLE,    -1,
-    /*    ARM */    ENT_ARM,        -1,       -1,       -1,      -1,        -1,        -1,        -1,         -1, ARMED,
+    /*    ARM */    ENT_ARM,        -1,       -1,       -1,      -1,        -1,        -1,        -1,     DISARM, ARMED,
     /*  ARMED */         -1,  LP_ARMED,       -1,       -1,      -1,        -1,     SWING,     CLASH,     DISARM,    -1,
     /*  CLASH */  ENT_CLASH,        -1,       -1,       -1,      -1,        -1,        -1,        -1,         -1, ARMED,
     /*  SWING */  ENT_SWING,  LP_SWING,       -1,       -1,      -1,     ARMED,        -1,     CLASH,         -1,    -1,
@@ -104,6 +104,7 @@ void CoreAudio::action( int id ) {
       beep(500*currentVolume, currentVolume); // One beep at current volume, varying length depending on volume setting
       return;
     case ENT_ARM:
+      originalVolume = currentVolume;
       useSmoothSwing = checkSmoothSwing();
       if (currentVolume > 0)
       {
@@ -115,6 +116,7 @@ void CoreAudio::action( int id ) {
       humString = moduleSettings->getRandomHumSound();
       return;
     case LP_ARMED:
+      originalVolume = currentVolume;
       if (!soundPlayFlashRaw.isPlaying())
       {
         soundPlayFlashRaw.play(humString.c_str());
@@ -235,6 +237,7 @@ void CoreAudio::action( int id ) {
       }
       return;
     case ENT_DISARM:
+      currentVolume = originalVolume;
       soundPlayFlashFXRaw.stop();
       if (useSmoothSwing)
       {

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -87,6 +87,7 @@ class CoreAudio: public Machine {
   // Params that can be tuned
   static constexpr float MAX_VOLUME = 1;                // 1 is the max volume. Use a lower number to be more quite e.g. at home
   float currentVolume = MAX_VOLUME;                            // Initial volume. Initally setting to max volume; may later load this from stored config
+  float originalVolume;
   bool firstTap = true;                                 // used to check for the first tap of a mute cycle
   bool useSmoothSwing = true;                           // smoothswing is used by default of proper files are loaded. If no smoothswing are present, then the normal swing is used automatically
                                                         // SmoothSwing V2, based on Thexter's excellent work.
@@ -119,6 +120,7 @@ Automaton::ATML::begin - Automaton Markup Language
       </VOLUME>
       <ARM index="2" on_enter="ENT_ARM">
         <ELSE>ARMED</ELSE>
+        <EVT_DISARM>DISARM</EVT_DISARM>
       </ARM>
       <ARMED index="3" on_loop="LP_ARMED">
         <EVT_SWING>SWING</EVT_SWING>

--- a/libraries/CoreLed/CoreLed.cpp
+++ b/libraries/CoreLed/CoreLed.cpp
@@ -10,7 +10,7 @@ CoreLed& CoreLed::begin(CoreSettings* cSet) {
     /*                 ON_ENTER      ON_LOOP  ON_EXIT  EVT_IDLE  EVT_RECHARGE  EVT_ARM  EVT_ARMED  EVT_SWING  EVT_CLASH  EVT_DISARM   ELSE */
     /*     IDLE */     ENT_IDLE,     LP_IDLE,      EXT_IDLE,       -1,     RECHARGE,     ARM,     ARMED,        -1,        -1,         -1,    -1,   
     /* RECHARGE */ ENT_RECHARGE, LP_RECHARGE,      -1,     IDLE,           -1,     ARM,        -1,        -1,        -1,         -1,    -1,
-    /*      ARM */      ENT_ARM,      LP_ARM, EXT_ARM,       -1,           -1,      -1,     ARMED,        -1,        -1,         -1,    -1,
+    /*      ARM */      ENT_ARM,      LP_ARM, EXT_ARM,       -1,           -1,      -1,     ARMED,        -1,        -1,     DISARM,    -1,
     /*    ARMED */    ENT_ARMED,          -1,      -1,       -1,           -1,      -1,        -1,     SWING,     CLASH,     DISARM,    -1,
     /*    CLASH */    ENT_CLASH,          -1,      -1,       -1,           -1,      -1,     ARMED,        -1,        -1,         -1,    -1,
     /*    SWING */    ENT_SWING,          -1,      -1,       -1,           -1,      -1,     ARMED,        -1,     CLASH,         -1,    -1,
@@ -112,6 +112,7 @@ void CoreLed::action( int id ) {
       }
       return;
     case ENT_ARM:
+      originalColorSetId = currentColorSetId;
       delay(ARMING_BLINK_TIME);
       turnOff();
       timer_color_selection.setFromNow(this,TIME_FOR_START_COLOR_SELECTION);
@@ -142,6 +143,7 @@ void CoreLed::action( int id ) {
       fadeIn();
       return;
     case ENT_ARMED:
+      originalColorSetId = currentColorSetId;
       changeColor(mainColor);
       return;
     case ENT_CLASH:
@@ -152,6 +154,8 @@ void CoreLed::action( int id ) {
       changeColor(swingColor);
       return;
     case ENT_DISARM:
+      currentColorSetId = originalColorSetId;
+      setCurrentColorSet(currentColorSetId);
       fadeOut();
       return;
   }

--- a/libraries/CoreLed/CoreLed.h
+++ b/libraries/CoreLed/CoreLed.h
@@ -55,6 +55,7 @@ class CoreLed: public Machine {
   atm_timer_millis timer_blink;
   atm_timer_millis timer_color_selection;
   int currentColorSetId = OFF;
+  int originalColorSetId;
   int nextColorSetId = OFF;
   ColorLed mainColor;
   ColorLed clashColor;
@@ -97,6 +98,7 @@ Automaton::ATML::begin - Automaton Markup Language
       </RECHARGE>
       <ARM index="2" on_enter="ENT_ARM" on_loop="LP_ARM" on_exit="EXT_ARM">
         <EVT_ARMED>ARMED</EVT_ARMED>
+        <EVT_DISARM>DISARM</EVT_ARMED>
       </ARM>
       <ARMED index="3" on_enter="ENT_ARMED">
         <EVT_SWING>SWING</EVT_SWING>

--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -9,7 +9,7 @@ CoreMotion& CoreMotion::begin() {
   const static state_t state_table[] PROGMEM = {
     /*                 ON_ENTER    ON_LOOP  ON_EXIT  EVT_VOLUME  EVT_DISARM  EVT_SWING  EVT_CLASH  EVT_ARMED  EVT_ARM   ELSE */
     /*   IDLE */       ENT_IDLE,   LP_IDLE,      -1,       -1,         -1,        -1,        -1,     ARMED,     ARM,    -1,
-    /*    ARM */        ENT_ARM,    LP_ARM,      -1,   VOLUME,         -1,        -1,        -1,     ARMED,      -1,    -1,
+    /*    ARM */        ENT_ARM,    LP_ARM,      -1,   VOLUME,     DISARM,        -1,        -1,     ARMED,      -1,    -1,
     /*  ARMED */      ENT_ARMED,  LP_ARMED,      -1,       -1,     DISARM,     SWING,     CLASH,        -1,      -1,    -1,
     /* DISARM */     ENT_DISARM,        -1,      -1,       -1,       IDLE,     ARMED,        -1,        -1,      -1,    -1,
     /*  CLASH */      ENT_CLASH,        -1,      -1,       -1,         -1,        -1,        -1,        -1,      -1, ARMED,
@@ -94,6 +94,7 @@ void CoreMotion::action( int id ) {
     case ENT_ARM:
       int1Status = 0;
       push( connectors, ON_ARM, 0, 0, 0 );
+      timer_horizontal.setFromNow(this,TIME_FOR_DISARM);
       return;
     case LP_ARM:
       if ((AccelZ < (ARM_POSITION - TOLERANCE_POSITION)) || 
@@ -101,6 +102,11 @@ void CoreMotion::action( int id ) {
           (swingSpeed > SWING_THRESHOLD))
       {
         timer_arm.setFromNow(this,TIME_FOR_CONFIRM_ARM);
+      }
+      if ((AccelZ < (HORIZONTAL_POSITION - TOLERANCE_POSITION)) || 
+          (AccelZ > (HORIZONTAL_POSITION + TOLERANCE_POSITION)))
+      {
+        timer_horizontal.setFromNow(this,TIME_FOR_DISARM);
       }
       return;
     case ENT_ARMED:

--- a/libraries/CoreMotion/CoreMotion.h
+++ b/libraries/CoreMotion/CoreMotion.h
@@ -95,6 +95,7 @@ Automaton::ATML::begin - Automaton Markup Language
       <ARM index="1" on_enter="ENT_ARM" on_loop="LP_ARM">
         <EVT_VOLUME>VOLUME</EVT_VOLUME>
         <EVT_ARMED>ARMED</EVT_ARMED>
+        <EVT_DISARM>DISARM</EVT_ARMED>
       </ARM>
       <ARMED index="2" on_enter="ENT_ARMED" on_loop="LP_ARMED">
         <EVT_DISARM>DISARM</EVT_DISARM>


### PR DESCRIPTION
# Description
When the saber is turned on with a gentle wrist rotation while in a vertical position, it enters a configuration mode where the user can select the color and sound. While in color selection mode, the saber goes through all available colors until the user confirms the selection, at which point the saber turns on with that color.

However, there was no way to cancel the color and sound selection process if the user changed their mind, meaning they had to wait for the selection to loop back to their desired option. To solve this issue, this merge request introduces the ability to turn off the saber while in the configuration state, by placing it horizontally. When the saber is turned off in this state, the color and sound selections made during the configuration process are reverted to their previous values, and the saber enters the idle state.

# Changes Made
- Added the ability to turn off the saber while in the configuration state by placing it horizontally
- Reverts the color and sound selections made during the configuration process to their previous values when the saber is turned off in this state

# Impact
This feature improves the usability of the lightsaber by allowing users to cancel the color and sound selection process if they change their mind, rather than having to wait for the selection to loop back around. It also introduces a new method of turning off the saber while in the configuration state, which was previously not possible.

# Testing
To test this feature, perform the following steps:

- Turn on the saber by using the gentle wrist rotation method while in a vertical position
- Select a different color
- Place the saber horizontally to turn it off
- Turn on the saber again using any of two ignition methods
- Confirm that the saber turns on with the previously selected color, rather than the last option selected in the configuration process