### PR TITLE
Refactor (Motion): Arm sensibility improve

### DIFF
--- a/libraries/CoreMotion/CoreMotion.cpp
+++ b/libraries/CoreMotion/CoreMotion.cpp
@@ -49,14 +49,14 @@ int CoreMotion::event( int id ) {
         this->state() == this->IDLE && 
         abs(GyroZ) > ARM_ALT_THRESHOLD_Z && 
         swingSpeed < SWING_THRESHOLD_HIGH &&
-        (!timer_no_vertical.expired( this )) &&
+        (timer_no_vertical.expired( this )) &&
         ((digitalRead(USB_PIN) == LOW) || DEBUG)
       );
     case EVT_ARM:
       return (
               swingSpeed < SWING_THRESHOLD &&
               abs(GyroZ) > ARM_THRESHOLD_Z &&
-              (!timer_vertical.expired( this )) &&
+              (timer_vertical.expired( this )) &&
               ((digitalRead(USB_PIN) == LOW) || DEBUG)
              );
   }
@@ -80,15 +80,15 @@ void CoreMotion::action( int id ) {
   switch ( id ) {
     case ENT_IDLE:
       push( connectors, ON_IDLE, 0, 0, 0 );
-      timer_vertical.setFromNow(this,0);
-      timer_no_vertical.setFromNow(this,0);
+      timer_vertical.setFromNow(this,TIME_FOR_START_ARM);
+      timer_no_vertical.setFromNow(this,TIME_FOR_ALT_START_ARM);
       return;
     case LP_IDLE:
       if(AccelZ >= (VERTICAL_POSITION - TOLERANCE_VERTICAL_POSITION)) {
-        timer_vertical.setFromNow(this,TIME_FOR_ALT_START_ARM);
-      } 
-      if(AccelZ < (VERTICAL_POSITION - TOLERANCE_VERTICAL_POSITION)) {
         timer_no_vertical.setFromNow(this,TIME_FOR_ALT_START_ARM);
+      } 
+      if(AccelZ < (VERTICAL_POSITION - TOLERANCE_VERTICAL_POSITION) && abs(GyroZ) < ARM_THRESHOLD_Z) {
+        timer_vertical.setFromNow(this,TIME_FOR_START_ARM);
       }
       return;
     case ENT_ARM:


### PR DESCRIPTION
## Changes Made

This refactor restores the waiting time before being able to transition to the configuration state (ARM) with the lightsaber in a vertical position. This waiting time was accidentally removed when implementing the fast ignition, which is what causes the high sensitivity of this ignition. With this small change, the ignition experience is improved

## Testing Instructions

To test this refactor, it is necessary to validate that when placing the lightsaber vertically, one must wait half a second before it responds to rotation and enters the configuration mode. Additionally, it is important to validate that the fast ignition continues to work properly.