### PR TITLE
Feature mixedfxhum

### DIFF
--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -128,10 +128,10 @@ void CoreAudio::action( int id ) {
       }
       return;
     case ENT_CLASH:
-      if (soundPlayFlashRaw.isPlaying())
+      /*if (soundPlayFlashRaw.isPlaying())
       {
         soundPlayFlashRaw.stop();
-      }
+      }*/
       if (useSmoothSwing)
       {
         soundPlayFlashSmoothSwingARaw.stop();
@@ -148,10 +148,10 @@ void CoreAudio::action( int id ) {
       {
         if (!soundPlayFlashFXRaw.isPlaying())
         {
-          if (soundPlayFlashRaw.isPlaying())
+          /*if (soundPlayFlashRaw.isPlaying())
           {
             soundPlayFlashRaw.stop();
-          }
+          }*/
           soundPlayFlashFXRaw.play(moduleSettings->getRandomSwingSound().c_str());
         }        
       }

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -121,6 +121,11 @@ void CoreAudio::action( int id ) {
       {
         soundPlayFlashRaw.play(humString.c_str());
       }
+      if (lowHum){
+        //we are coming from a clash or legacy swing: set high hum back
+        mainMixer.gain(CHANNEL_HUM, currentVolume);
+        lowHum = false;
+      }
       if (useSmoothSwing)
       {
         soundPlayFlashSmoothSwingARaw.stop();
@@ -128,10 +133,12 @@ void CoreAudio::action( int id ) {
       }
       return;
     case ENT_CLASH:
-      /*if (soundPlayFlashRaw.isPlaying())
+      if (soundPlayFlashRaw.isPlaying())
       {
-        soundPlayFlashRaw.stop();
-      }*/
+        //soundPlayFlashRaw.stop();
+        mainMixer.gain(CHANNEL_HUM, ATT * currentVolume); //allows the clash to be heard while hum continues -3dB lower
+        lowHum = true;
+      }
       if (useSmoothSwing)
       {
         soundPlayFlashSmoothSwingARaw.stop();
@@ -148,10 +155,12 @@ void CoreAudio::action( int id ) {
       {
         if (!soundPlayFlashFXRaw.isPlaying())
         {
-          /*if (soundPlayFlashRaw.isPlaying())
+          if (soundPlayFlashRaw.isPlaying())
           {
-            soundPlayFlashRaw.stop();
-          }*/
+            // soundPlayFlashRaw.stop();
+            mainMixer.gain(CHANNEL_HUM, ATT * currentVolume);
+            lowHum = true;
+          }
           soundPlayFlashFXRaw.play(moduleSettings->getRandomSwingSound().c_str());
         }        
       }
@@ -230,7 +239,9 @@ void CoreAudio::action( int id ) {
         {
           if (soundPlayFlashRaw.isPlaying())
           {
-            soundPlayFlashRaw.stop();
+            //soundPlayFlashRaw.stop();
+            mainMixer.gain(CHANNEL_HUM, ATT * currentVolume); //allows the clash to be heard while hum continues 10log(ATT) dB lower
+            lowHum = true;
           }
           soundPlayFlashFXRaw.play(moduleSettings->getRandomSwingSound().c_str());
         }        

--- a/libraries/CoreAudio/CoreAudio.cpp
+++ b/libraries/CoreAudio/CoreAudio.cpp
@@ -135,8 +135,7 @@ void CoreAudio::action( int id ) {
     case ENT_CLASH:
       if (soundPlayFlashRaw.isPlaying())
       {
-        //soundPlayFlashRaw.stop();
-        mainMixer.gain(CHANNEL_HUM, ATT * currentVolume); //allows the clash to be heard while hum continues -3dB lower
+        mainMixer.gain(CHANNEL_HUM, ATTENUATION_RATE * currentVolume); //allows the clash to be heard while hum continues -3dB lower
         lowHum = true;
       }
       if (useSmoothSwing)
@@ -157,8 +156,7 @@ void CoreAudio::action( int id ) {
         {
           if (soundPlayFlashRaw.isPlaying())
           {
-            // soundPlayFlashRaw.stop();
-            mainMixer.gain(CHANNEL_HUM, ATT * currentVolume);
+            mainMixer.gain(CHANNEL_HUM, ATTENUATION_RATE * currentVolume);
             lowHum = true;
           }
           soundPlayFlashFXRaw.play(moduleSettings->getRandomSwingSound().c_str());
@@ -239,8 +237,7 @@ void CoreAudio::action( int id ) {
         {
           if (soundPlayFlashRaw.isPlaying())
           {
-            //soundPlayFlashRaw.stop();
-            mainMixer.gain(CHANNEL_HUM, ATT * currentVolume); //allows the clash to be heard while hum continues 10log(ATT) dB lower
+            mainMixer.gain(CHANNEL_HUM, ATTENUATION_RATE * currentVolume); //allows the clash to be heard while hum continues 10log(ATTENUATION_RATE) dB lower
             lowHum = true;
           }
           soundPlayFlashFXRaw.play(moduleSettings->getRandomSwingSound().c_str());

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -22,6 +22,8 @@
 #define BEEP_FREQUENCY 1000
 #define AUDIO_BLOCK 16
 
+#define ATT 0.5
+
 class CoreAudio: public Machine {
 
  public:
@@ -88,6 +90,7 @@ class CoreAudio: public Machine {
   static constexpr float MAX_VOLUME = 1;                // 1 is the max volume. Use a lower number to be more quite e.g. at home
   float currentVolume = MAX_VOLUME;                            // Initial volume. Initally setting to max volume; may later load this from stored config
   float originalVolume;
+  bool lowHum = false;                                  // switch to check hum volume 
   bool firstTap = true;                                 // used to check for the first tap of a mute cycle
   bool useSmoothSwing = true;                           // smoothswing is used by default of proper files are loaded. If no smoothswing are present, then the normal swing is used automatically
                                                         // SmoothSwing V2, based on Thexter's excellent work.

--- a/libraries/CoreAudio/CoreAudio.h
+++ b/libraries/CoreAudio/CoreAudio.h
@@ -22,8 +22,6 @@
 #define BEEP_FREQUENCY 1000
 #define AUDIO_BLOCK 16
 
-#define ATT 0.5
-
 class CoreAudio: public Machine {
 
  public:
@@ -105,6 +103,7 @@ class CoreAudio: public Machine {
   static constexpr float TRANSITION_1_WIDTH = 60.0;     // width angle in degreese of the first trasition 
   static constexpr float TRANSITION_2_WIDTH = 160.0;    // width angle in degreese of the second trasition, which is 180 deg away from the first transition
   static constexpr float SMOOTHING_FACTOR = 0.2;
+  static constexpr float ATTENUATION_RATE = 0.5;        // Attenuation rate in linear (here -3dB)
 };
 
 /* 


### PR DESCRIPTION
This feature allows clash sounds to be mixed with the hum, so it does not start over every time we clash.

Instead of stopping the hum sound, the channel gain is set to -3dB, so we can hear the clash sound properly before getting back to maximum volume.

For complex ~~meme~~ fonts, it allows a smoother and better sound experience overall